### PR TITLE
Fix bindings to be compatible with node/esm/rescript-ssg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,40 @@
 {
   "name": "@ahrefs/bs-numeral",
-  "version": "0.1.4",
-  "lockfileVersion": 1,
+  "version": "0.1.5",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "bs-platform": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.5.tgz",
-      "integrity": "sha512-wK+yUx/5ojlrxgk/EB3Hla7+9NEnE8PxtGb71e4IsKnWPXrRAaVtdTuoWWClv8z77xntOFg8qTgYfYyh9xLMWA==",
-      "dev": true
+  "packages": {
+    "": {
+      "name": "@ahrefs/bs-numeral",
+      "version": "0.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "numeral": "2.0.6"
+      },
+      "devDependencies": {
+        "bs-platform": "^9.0.2"
+      }
     },
-    "numeral": {
+    "node_modules/bs-platform": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-9.0.2.tgz",
+      "integrity": "sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "bsb": "bsb",
+        "bsc": "bsc",
+        "bsrefmt": "bsrefmt",
+        "bstracing": "lib/bstracing"
+      }
+    },
+    "node_modules/numeral": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY=",
+      "engines": {
+        "node": "*"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahrefs/bs-numeral",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Bucklescript bindings for Numeral",
   "homepage": "https://github.com/ahrefs/bs-numeral#readme",
   "repository": {
@@ -22,7 +22,7 @@
     "watch": "bsb -make-world -w"
   },
   "devDependencies": {
-    "bs-platform": "^4.0.4"
+    "bs-platform": "^9.0.2"
   },
   "dependencies": {
     "numeral": "2.0.6"

--- a/src/BsNumeral.re
+++ b/src/BsNumeral.re
@@ -1,15 +1,15 @@
 type t;
 
-[@bs.module]
+[@bs.module "numeral"]
 external make:
   (
   [@bs.unwrap]
   [ | `Str(string) | `Int(int) | `Float(float) | `Numeral(t)]
   ) =>
   t =
-  "numeral";
+  "default";
 
-[@bs.module] external makeEmpty: unit => t = "numeral";
+[@bs.module "numeral"] external makeEmpty: unit => t = "default";
 
 [@bs.send] external value: t => Js.nullable(float) = "value";
 


### PR DESCRIPTION
This is a fix for the issue: https://github.com/ahrefs/bs-numeral/issues/2